### PR TITLE
move tier to ets

### DIFF
--- a/lib/statsig_ex.ex
+++ b/lib/statsig_ex.ex
@@ -56,7 +56,6 @@ defmodule StatsigEx do
     Process.send_after(self(), :reload, state.reload_interval)
     Process.send_after(self(), :flush, state.flush_interval)
     {:ok, Map.put(state, :last_sync, last_sync)}
-    # end
   end
 
   @doc """
@@ -99,6 +98,14 @@ defmodule StatsigEx do
   def state(server \\ __MODULE__), do: GenServer.call(server, :state)
 
   def lookup(name, type, server \\ __MODULE__), do: :ets.lookup(ets_name(server), {name, type})
+
+  def get_tier(server) do
+    :ets.lookup(ets_name(server), "tier")
+    |> case do
+      [{"tier", t}] -> t
+      _ -> nil
+    end
+  end
 
   def all(type, server \\ __MODULE__),
     do: :ets.match(ets_name(server), {{:"$1", type}, :_}) |> List.flatten()
@@ -160,14 +167,6 @@ defmodule StatsigEx do
           nil -> {:system, "STATSIG_API_KEY"}
           v -> v
         end
-    end
-  end
-
-  defp get_tier(server) do
-    :ets.lookup(ets_name(server), "tier")
-    |> case do
-      [{"tier", t}] -> t
-      _ -> nil
     end
   end
 

--- a/test/statsig_ex_test.exs
+++ b/test/statsig_ex_test.exs
@@ -1,0 +1,6 @@
+defmodule StatsigEx.StatsigExTest do
+  use ExUnit.Case
+  test "retrieving the tier works as expected" do
+    assert :test_test == StatsigEx.get_tier(:test)
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,3 @@
 Application.ensure_all_started(:statsig)
-StatsigEx.start_link(name: :test)
+StatsigEx.start_link(name: :test, tier: :test_test)
 ExUnit.start(exclude: [:flakey])


### PR DESCRIPTION
With the tier in the state we need to make a call to the GenServer on each flag eval, move to ets to avoid that.